### PR TITLE
Updating copy for Postgres.app

### DIFF
--- a/templates/pages/download/macosx.html
+++ b/templates/pages/download/macosx.html
@@ -32,18 +32,11 @@ PostgreSQL 9.0 and later, Mac OS X 10.5 and above are supported for 32 and
 the installer from EnterpriseDB for all supported versions.
 </p>
 
-{%comment%}
-Not released yet (just beta), and nobody on packagers handling it
-
 <h2>Postgres.app</h2>
 <p>
-<a href="http://postgresapp.com">Postgres.app</a> is a native Mac OS X app
-designed for developer who wants a
-"desktop style" installer. It is not intended for server deployments, but
-makes starting and stopping and general handling of a local PostgreSQL
-server for development easy.
+<a href="http://postgresapp.com">Postgres.app</a> is a simple, native Mac OS X app that runs in the menubar without the need of an installer. Open the app, and you have a PostgreSQL server 
+ready and awaiting new connections. Close the app, and the server shuts down.
 </p>
-{%endcomment%}
 
 <h2>Fink</h2>
 


### PR DESCRIPTION
Now that Postgres.app is out of beta, we should consider adding it to the downloads page on postgresql.org.

This patch removes the comment tag and updates the copy for the app description.
