### PR TITLE
Fix typo Homewbrew => Homebrew

### DIFF
--- a/templates/pages/download/macosx.html
+++ b/templates/pages/download/macosx.html
@@ -144,7 +144,7 @@ can be found using the portfiles search tool on the MacPorts website.
 
 <p>
 PostgreSQL can also be installed on macOS
-using <a href="http://brew.sh">Homebrew</a>. Please see the Homewbrew
+using <a href="http://brew.sh">Homebrew</a>. Please see the Homebrew
 documentation for information on how to install packages.
 </p>
 


### PR DESCRIPTION
Just fixes typo (Homewbrew => Homebrew) in the downloads page for MacOS.