### PR TITLE
point search engines at the /current/ docs version

### DIFF
--- a/templates/docs/docspage.html
+++ b/templates/docs/docspage.html
@@ -80,7 +80,7 @@
                       {% for ver in supported_versions %}
                         {% if not forloop.first %} / {% endif %}
                         {% if ver.version.current %}
-                          <a href="/docs/current/{{ver.file}}" title="PostgreSQL {{ver.display_version}} - {{page.title}}" {% if ver.version == page.version %}class="docs-version-selected"{% endif %}>Current</a>
+                          <a rel="canonical" href="/docs/current/{{ver.file}}" title="PostgreSQL {{ver.display_version}} - {{page.title}}" {% if ver.version == page.version %}class="docs-version-selected"{% endif %}>Current</a>
                           (<a href="/docs/{{ver.display_version}}/{{ver.file}}" title="PostgreSQL {{ver.display_version}} - {{page.title}}" {% if ver.version == page.version %}class="docs-version-selected"{% endif %}>{{ver.display_version}}</a>)
                         {% else %}
                           <a href="/docs/{{ver.display_version}}/{{ver.file}}" title="PostgreSQL {{ver.display_version}} - {{page.title}}" {% if ver.version == page.version %}class="docs-version-selected"{% endif %}>{{ver.display_version}}</a>


### PR DESCRIPTION
Problem description:
https://www.postgresql.org/message-id/CANNMO%2B%2BkxJmaaB7X6hq_8SqcEruySZrF%3DUkcPm-EG1JCKVascw%40mail.gmail.com

This appears to be a quick fix using rel=canonical
https://yoast.com/rel-canonical/
