### PR TITLE
Fix pagination link handling

### DIFF
--- a/pgweb/search/views.py
+++ b/pgweb/search/views.py
@@ -229,7 +229,7 @@ def search(request):
             'query': request.GET['q'],
             'pagelinks': "&nbsp;".join(
                 generate_pagelinks(pagenum,
-                                   totalhits // hitsperpage + 1,
+                                   (totalhits - 1) // hitsperpage + 1,
                                    querystr)),
             'hits': [{
                 'date': h['d'],
@@ -305,7 +305,7 @@ def search(request):
             'query': request.GET['q'],
             'pagelinks': "&nbsp;".join(
                 generate_pagelinks(pagenum,
-                                   totalhits // hitsperpage + 1,
+                                   (totalhits - 1) // hitsperpage + 1,
                                    querystr)),
             'hits': [{
                 'title': h[3],


### PR DESCRIPTION
Hi!

Thanks for maintaining pgweb.

I noticed this issue when searching mailing lists, and I figured I could probably fix it, so here
I am. It's been ages since I've done done any python, but I think this is correct. I did not test
the change in the application, but I did test the logic in a local python console and I think it's
right.

Commit text follows explaining the change:

---

If the total number of search results is divisible by the page size, the page count
is mis-calculated and there's a link to an additional page of results, even though there
are no more results and that page is empty.

See issue here: https://www.postgresql.org/search/?m=1&q=contrib&l=76&d=365&s=r&p=2

At the moment, this has 20 results but a link to a second page, which is empty with a label of
"Results 21-20 of 20." Previous and Next works still work fine, but that second page
does not really need to be there.

This changes the page count calculation to avoid this issue.
