### PR TITLE
Debian: Use the recommended way to manage repository key.

### DIFF
--- a/templates/pages/download/linux/debian.html
+++ b/templates/pages/download/linux/debian.html
@@ -46,10 +46,10 @@ To use the apt repository, follow these steps:
 
 <div class="pg-script-container">
     <pre id="script-box" class="code"># Create the file repository configuration:
-sudo sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+sudo sh -c 'echo "deb [signed-by=/etc/apt/trusted.gpg.d/ACCC4CF8.gpg] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
 
 # Import the repository signing key:
-wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+wget --quiet -O -  https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo sh -c "gpg -o /etc/apt/trusted.gpg.d/ACCC4CF8.gpg --dearmor"
 
 # Update the package lists:
 sudo apt-get update

--- a/templates/pages/download/linux/ubuntu.html
+++ b/templates/pages/download/linux/ubuntu.html
@@ -47,10 +47,10 @@ To use the apt repository, follow these steps:
 
 <div class="pg-script-container">
     <pre id="script-box" class="code"># Create the file repository configuration:
-sudo sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+sudo sh -c 'echo "deb [signed-by=/etc/apt/trusted.gpg.d/ACCC4CF8.gpg] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
 
 # Import the repository signing key:
-wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo sh -c "gpg -o /etc/apt/trusted.gpg.d/ACCC4CF8.gpg --dearmor"
 
 # Update the package lists:
 sudo apt-get update


### PR DESCRIPTION
As described in the Debian wiki:
https://wiki.debian.org/DebianRepository/UseThirdParty

I'm using Debian 12, and I tested this on it.
As Ubuntu is based on Debian, I guess it's the same.